### PR TITLE
Proposed Soul Persuasion Change

### DIFF
--- a/game/resource/addon_english.txt
+++ b/game/resource/addon_english.txt
@@ -802,8 +802,9 @@
 		"DOTA_Tooltip_Ability_chen_soul_persuasion_souls_tick_rate"			"INTERVAL FOR GAIN SOULS:"
 
 		"DOTA_Tooltip_ability_chen_soul_persuasion_aghanim_description"		"Chen summon several creeps for one cast ability"
+		"DOTA_Tooltip_ability_chen_soul_persuasion_creeps_max_summoned" 	"MAX CREEP COUNT:"
 		"DOTA_Tooltip_ability_chen_soul_persuasion_creeps_with_aghanim" 	"CREEPS WITH SCEPTER:"
-
+		"dota_chen_soul_persuasion_max_limit_error"				"Cannot cast because you have too many summoned creeps."
 
 		"DOTA_Tooltip_ability_special_chen_soul_persuasion_tickrate"		"{s:value} seconds for soul gain interval for Soul Persuasion"
 
@@ -1072,7 +1073,7 @@
 
 		"show_chat"	"Show Chat"
 		"npc_dummy_cosmetic_caster"	"Dummy Caster"
-		
+
 		"collection_header"		"COLLECTION"
 		"player_no_boost"		"NO BOOST"
 		"player_base_booster"	"BASE BOOST"
@@ -1835,14 +1836,14 @@
 		"open_in_browser"				"CLICK HERE TO GO TO PATREON.COM\nAND SEND US YOUR STEAM URL AGAIN"
 		"link_steam"					"Link your Steam account on Patreon in order to regain your perks"
 		"warning_patreon_ids_text"		"We are terribly sorry but our previous server died unexpectedly.\nWe now have to manually recollect all the STEAM URL/IDS.\nIf you do not send us your steam URL or steamID we wont be adle to grant you benefits."
-		
+
 		"feedback"				"FEEDBACK"
 		"default_feedback"		"Write here your feedback, suggestion and ideas"
 		"feedback_send"			"SEND"
 		"feedback_cooldown"		"You recently sent a message. Wait little time for send new message."
 		"feedback_blocked"		"Write something before send message."
 		"feedback_top_menu_hint"	"Send feedback for developers team"
-		
+
 		"voting_to_kick_no_kick_new_players"	"You cannot kick new players"
 
 		"fix_game_header"		"CUSTOM GAME LOBBIES NEED FIXING"

--- a/game/resource/addon_english.txt
+++ b/game/resource/addon_english.txt
@@ -804,8 +804,9 @@
 		"DOTA_Tooltip_ability_chen_soul_persuasion_aghanim_description"		"Chen summon several creeps for one cast ability"
 		"DOTA_Tooltip_ability_chen_soul_persuasion_creeps_max_summoned" 	"MAX CREEP COUNT:"
 		"DOTA_Tooltip_ability_chen_soul_persuasion_creeps_with_aghanim" 	"CREEPS WITH SCEPTER:"
-		"dota_chen_soul_persuasion_max_limit_error"				"Cannot cast because you have too many summoned creeps."
-
+		"dota_chen_soul_persuasion_max_limit_error"							"Cannot cast because you have too many summoned creeps."
+		"DOTA_Tooltip_ability_chen_soul_persuasion_scepter_description"		"Chen summons <b>two</b> creeps instead of one."
+		
 		"DOTA_Tooltip_ability_special_chen_soul_persuasion_tickrate"		"{s:value} seconds for soul gain interval for Soul Persuasion"
 
 		"DOTA_Tooltip_ability_special_bonus_unique_chen_4"			"+{s:value} Soul Persuasion Minimum Health"

--- a/game/resource/addon_russian.txt
+++ b/game/resource/addon_russian.txt
@@ -697,10 +697,13 @@
 		"DOTA_Tooltip_Ability_chen_soul_persuasion_Description"		"<font color='#70EA72'>Chen периодически получает</font> %souls_per_second% <font color='#70EA72'>душу или</font> %souls_per_kill% <font color='#70EA72'>душ за убйиство вражеского героя. При активации умения Chen призывает случайного нейтрального крипа. </font><br><br><font color='#819af7'>МАЛЕНЬКИЙ КРИП</font>: %souls_summon_little% душ(и), перезарядка - %cooldown_little% сек., стомость - %manacost_little% маны<br><font color='#9e63f7'>СРЕДНИЙ КРИП</font>: %souls_summon_middle% душ(и), перезарядка - %cooldown_middle% сек., %manacost_middle% маны<br><font color='#d52222'>БОЛЬШИЙ КРИП</font>: %souls_summon_big% душ(и), перезарядка - %cooldown_big% сек., %manacost_big% маны<br><font color='#f8c71b'>ДРЕВНИЙ КРИП</font>: %souls_summon_ancient% душ(и), перезарядка - %cooldown_ancient% сек., %manacost_ancient% маны"
 		"DOTA_Tooltip_Ability_chen_soul_persuasion_souls_limit"		"ЛИМИТ ДУШ:"
 		"DOTA_Tooltip_Ability_chen_soul_persuasion_souls_tick_rate"	"ИНТЕРВАЛ ПОЛУЧЕНИЯ ДУШ:"
+		"dota_chen_soul_persuasion_max_limit_error"					"Призвано максимальное количество существ."
+		"DOTA_Tooltip_ability_chen_soul_persuasion_scepter_description"		"Chen призывает <b>двух</b> существ вместо одного."
 		
 		"DOTA_Tooltip_ability_special_chen_soul_persuasion_tickrate"	"{s:value} сек. к интервалу получения душ от Soul Persuasion"
 		
 		"DOTA_Tooltip_ability_chen_soul_persuasion_aghanim_description"		"Chen призывается несколько существ вместо одного"
+		"DOTA_Tooltip_ability_chen_soul_persuasion_creeps_max_summoned" 	"МАКСИМУМ СУЩЕСТВ:"
 		"DOTA_Tooltip_ability_chen_soul_persuasion_creeps_with_aghanim" 	"СУЩЕСТВ СО СКИПЕТРОМ:"
         		
 		"DOTA_Tooltip_ability_special_bonus_unique_chen_4"			"+{s:value} к мин. здоровью крипов от Soul Persuasion"

--- a/game/scripts/npc/npc_abilities_custom.txt
+++ b/game/scripts/npc/npc_abilities_custom.txt
@@ -1131,6 +1131,11 @@
 			"17"
 			{
 				"var_type"				"FIELD_INTEGER"
+				"creeps_max_summoned"	"10"
+			}
+			"18"
+			{
+				"var_type"				"FIELD_INTEGER"
 				"creeps_with_aghanim"	"2"
 				"RequiresScepter"		"1"
 			}

--- a/game/scripts/vscripts/abilities/heroes/chen/chen_soul_persuasion.lua
+++ b/game/scripts/vscripts/abilities/heroes/chen/chen_soul_persuasion.lua
@@ -1,4 +1,6 @@
 chen_soul_persuasion = class({})
+chen_soul_persuasion.summon_list = chen_soul_persuasion.summon_list or {}
+
 LinkLuaModifier("chen_soul_persuasion_passive", "abilities/heroes/chen/chen_soul_persuasion_passive", LUA_MODIFIER_MOTION_NONE)
 
 function chen_soul_persuasion:GetIntrinsicModifierName()
@@ -15,6 +17,15 @@ function chen_soul_persuasion:OnSpellStart()
 		self:EndCooldown()
 		return
 	end
+	
+	local summonMax = self:GetSpecialValueFor("creeps_max_summoned")
+	self:ValidateCurrentSummons()
+	if #self.summon_list >= summonMax then
+		CustomGameEventManager:Send_ServerToPlayer(parent:GetPlayerOwner(), "display_custom_error", { message = "#dota_chen_soul_persuasion_max_limit_error" })
+		self:EndCooldown()
+		return
+	end
+	
 	local currentData = self.abilityData[summonSouls]
 
 	if parent:GetMana() < currentData.manacost then
@@ -24,14 +35,6 @@ function chen_soul_persuasion:OnSpellStart()
 				message = "#dota_hud_error_not_enough_mana"
 			})
 		end
-		self:EndCooldown()
-		return
-	end
-
-	local summonMax = self:GetSpecialValueFor("creeps_max_summoned")
-	self:ValidateCurrentSummons()
-	if #self.summon_list >= summonMax then
-		CustomGameEventManager:Send_ServerToPlayer(parent:GetPlayerOwner(), "display_custom_error", { message = "#dota_chen_soul_persuasion_max_limit_error" })
 		self:EndCooldown()
 		return
 	end
@@ -47,7 +50,6 @@ function chen_soul_persuasion:OnSpellStart()
 	self:StartCooldown(currentData.cooldown * parent:GetCooldownReduction())
 end
 
-chen_soul_persuasion.summon_list = {}
 function chen_soul_persuasion:ValidateCurrentSummons()
 	for unit_index = #self.summon_list, 1, -1 do
 		local unit_handle = self.summon_list[unit_index]


### PR DESCRIPTION
resolves: https://github.com/arcadia-redux/overthrow2/issues/141
This change focuses on the second option, where Chen can only summon if he is below limit, and restrict him from summoning if he is at the limit.
With scepter, Chen can summon 2 units, but if he is 1 unit below limit, he will only summon 1 more.

Need Sheodar to check for mistakes before merging.